### PR TITLE
Fix #14 by forcing the event loop to consume VulkanApp instance

### DIFF
--- a/src/tutorials/01_instance_creation.rs
+++ b/src/tutorials/01_instance_creation.rs
@@ -77,7 +77,11 @@ impl VulkanApp {
         instance
     }
 
-    pub fn main_loop(self, event_loop: EventLoop<()>) {
+    fn draw_frame(&mut self) {
+        // Drawing will be here
+    }
+
+    pub fn main_loop(mut self, event_loop: EventLoop<()>) {
 
         event_loop.run(move |event, _, control_flow| {
 
@@ -101,6 +105,9 @@ impl VulkanApp {
                         },
                         | _ => {},
                     }
+                },
+                | Event::EventsCleared => {
+                    self.draw_frame();
                 },
                 _ => (),
             }

--- a/src/tutorials/02_validation_layers.rs
+++ b/src/tutorials/02_validation_layers.rs
@@ -201,7 +201,11 @@ impl VulkanApp {
         }
     }
 
-    pub fn main_loop(self, event_loop: EventLoop<()>) {
+    fn draw_frame(&mut self) {
+        // Drawing will be here
+    }
+
+    pub fn main_loop(mut self, event_loop: EventLoop<()>) {
 
         event_loop.run(move |event, _, control_flow| {
 
@@ -225,6 +229,9 @@ impl VulkanApp {
                         },
                         | _ => {},
                     }
+                },
+                | Event::EventsCleared => {
+                    self.draw_frame();
                 },
                 _ => (),
             }

--- a/src/tutorials/03_physical_device_selection.rs
+++ b/src/tutorials/03_physical_device_selection.rs
@@ -202,6 +202,10 @@ impl VulkanApp {
 
         queue_family_indices
     }
+
+    fn draw_frame(&mut self) {
+        // Drawing will be here
+    }
 }
 
 impl Drop for VulkanApp {
@@ -218,7 +222,7 @@ impl Drop for VulkanApp {
 
 // Fix content -------------------------------------------------------------------------------
 impl VulkanApp {
-    pub fn main_loop(self, event_loop: EventLoop<()>) {
+    pub fn main_loop(mut self, event_loop: EventLoop<()>) {
 
          event_loop.run(move |event, _, control_flow| {
 
@@ -242,6 +246,9 @@ impl VulkanApp {
                         },
                         | _ => {},
                     }
+                },
+                | Event::EventsCleared => {
+                    self.draw_frame();
                 },
                 _ => (),
             }

--- a/src/tutorials/04_logical_device.rs
+++ b/src/tutorials/04_logical_device.rs
@@ -187,6 +187,10 @@ impl VulkanApp {
 
         queue_family_indices
     }
+
+    fn draw_frame(&mut self) {
+        // Drawing will be here
+    }
 }
 
 impl Drop for VulkanApp {
@@ -205,7 +209,7 @@ impl Drop for VulkanApp {
 
 // Fix content -------------------------------------------------------------------------------
 impl VulkanApp {
-    pub fn main_loop(self, event_loop: EventLoop<()>) {
+    pub fn main_loop(mut self, event_loop: EventLoop<()>) {
 
          event_loop.run(move |event, _, control_flow| {
 
@@ -229,6 +233,9 @@ impl VulkanApp {
                         },
                         | _ => {},
                     }
+                },
+                | Event::EventsCleared => {
+                    self.draw_frame();
                 },
                 _ => (),
             }

--- a/src/tutorials/05_window_surface.rs
+++ b/src/tutorials/05_window_surface.rs
@@ -256,6 +256,10 @@ impl VulkanApp {
 
         queue_family_indices
     }
+
+    fn draw_frame(&mut self) {
+        // Drawing will be here
+    }
 }
 
 impl Drop for VulkanApp {
@@ -276,7 +280,7 @@ impl Drop for VulkanApp {
 
 // Fix content -------------------------------------------------------------------------------
 impl VulkanApp {
-    pub fn main_loop(self, event_loop: EventLoop<()>) {
+    pub fn main_loop(mut self, event_loop: EventLoop<()>) {
 
          event_loop.run(move |event, _, control_flow| {
 
@@ -300,6 +304,9 @@ impl VulkanApp {
                         },
                         | _ => {},
                     }
+                },
+                | Event::EventsCleared => {
+                    self.draw_frame();
                 },
                 _ => (),
             }

--- a/src/tutorials/06_swap_chain_creation.rs
+++ b/src/tutorials/06_swap_chain_creation.rs
@@ -508,6 +508,10 @@ impl VulkanApp {
             }
         }
     }
+
+    fn draw_frame(&mut self) {
+        // Drawing will be here
+    }
 }
 
 impl Drop for VulkanApp {
@@ -529,7 +533,7 @@ impl Drop for VulkanApp {
 
 // Fix content -------------------------------------------------------------------------------
 impl VulkanApp {
-    pub fn main_loop(self, event_loop: EventLoop<()>) {
+    pub fn main_loop(mut self, event_loop: EventLoop<()>) {
 
          event_loop.run(move |event, _, control_flow| {
 
@@ -553,6 +557,9 @@ impl VulkanApp {
                         },
                         | _ => {},
                     }
+                },
+                | Event::EventsCleared => {
+                    self.draw_frame();
                 },
                 _ => (),
             }

--- a/src/tutorials/07_image_view.rs
+++ b/src/tutorials/07_image_view.rs
@@ -145,6 +145,10 @@ impl VulkanApp {
 
         swapchain_imageviews
     }
+
+    fn draw_frame(&mut self) {
+        // Drawing will be here
+    }
 }
 
 impl Drop for VulkanApp {
@@ -170,7 +174,7 @@ impl Drop for VulkanApp {
 
 // Fix content -------------------------------------------------------------------------------
 impl VulkanApp {
-    pub fn main_loop(self, event_loop: EventLoop<()>) {
+    pub fn main_loop(mut self, event_loop: EventLoop<()>) {
 
          event_loop.run(move |event, _, control_flow| {
 
@@ -194,6 +198,9 @@ impl VulkanApp {
                         },
                         | _ => {},
                     }
+                },
+                | Event::EventsCleared => {
+                    self.draw_frame();
                 },
                 _ => (),
             }

--- a/src/tutorials/08_graphics_pipeline.rs
+++ b/src/tutorials/08_graphics_pipeline.rs
@@ -106,6 +106,10 @@ impl VulkanApp {
     fn create_graphics_pipeline() {
         // leave it empty right now
     }
+
+    fn draw_frame(&mut self) {
+        // Drawing will be here
+    }
 }
 
 impl Drop for VulkanApp {
@@ -131,7 +135,7 @@ impl Drop for VulkanApp {
 
 // Fix content -------------------------------------------------------------------------------
 impl VulkanApp {
-    pub fn main_loop(self, event_loop: EventLoop<()>) {
+    pub fn main_loop(mut self, event_loop: EventLoop<()>) {
 
          event_loop.run(move |event, _, control_flow| {
 
@@ -155,6 +159,9 @@ impl VulkanApp {
                         },
                         | _ => {},
                     }
+                },
+                | Event::EventsCleared => {
+                    self.draw_frame();
                 },
                 _ => (),
             }

--- a/src/tutorials/09_shader_modules.rs
+++ b/src/tutorials/09_shader_modules.rs
@@ -174,6 +174,10 @@ impl VulkanApp {
 
         bytes_code
     }
+
+    fn draw_frame(&mut self) {
+        // Drawing will be here
+    }
 }
 
 impl Drop for VulkanApp {
@@ -198,7 +202,7 @@ impl Drop for VulkanApp {
 }
 
 impl VulkanApp {
-    pub fn main_loop(self, event_loop: EventLoop<()>) {
+    pub fn main_loop(mut self, event_loop: EventLoop<()>) {
 
          event_loop.run(move |event, _, control_flow| {
 
@@ -222,6 +226,9 @@ impl VulkanApp {
                         },
                         | _ => {},
                     }
+                },
+                | Event::EventsCleared => {
+                    self.draw_frame();
                 },
                 _ => (),
             }

--- a/src/tutorials/10_fixed_functions.rs
+++ b/src/tutorials/10_fixed_functions.rs
@@ -297,6 +297,10 @@ impl VulkanApp {
 
         pipeline_layout
     }
+
+    fn draw_frame(&mut self) {
+        // Drawing will be here
+    }
 }
 
 impl Drop for VulkanApp {
@@ -325,7 +329,7 @@ impl Drop for VulkanApp {
 
 // Fix content -------------------------------------------------------------------------------
 impl VulkanApp {
-    pub fn main_loop(self, event_loop: EventLoop<()>) {
+    pub fn main_loop(mut self, event_loop: EventLoop<()>) {
 
          event_loop.run(move |event, _, control_flow| {
 
@@ -349,6 +353,9 @@ impl VulkanApp {
                         },
                         | _ => {},
                     }
+                },
+                | Event::EventsCleared => {
+                    self.draw_frame();
                 },
                 _ => (),
             }

--- a/src/tutorials/11_render_passes.rs
+++ b/src/tutorials/11_render_passes.rs
@@ -351,6 +351,10 @@ impl VulkanApp {
                 .expect("Failed to create render pass!")
         }
     }
+
+    fn draw_frame(&mut self) {
+        // Drawing will be here
+    }
 }
 
 impl Drop for VulkanApp {
@@ -380,7 +384,7 @@ impl Drop for VulkanApp {
 
 // Fix content -------------------------------------------------------------------------------
 impl VulkanApp {
-    pub fn main_loop(self, event_loop: EventLoop<()>) {
+    pub fn main_loop(mut self, event_loop: EventLoop<()>) {
 
          event_loop.run(move |event, _, control_flow| {
 
@@ -404,6 +408,9 @@ impl VulkanApp {
                         },
                         | _ => {},
                     }
+                },
+                | Event::EventsCleared => {
+                    self.draw_frame();
                 },
                 _ => (),
             }

--- a/src/tutorials/12_graphics_pipeline_complete.rs
+++ b/src/tutorials/12_graphics_pipeline_complete.rs
@@ -338,6 +338,10 @@ impl VulkanApp {
 
         (graphics_pipelines[0], pipeline_layout)
     }
+
+    fn draw_frame(&mut self) {
+        // Drawing will be here
+    }
 }
 
 impl Drop for VulkanApp {
@@ -368,7 +372,7 @@ impl Drop for VulkanApp {
 
 // Fix content -------------------------------------------------------------------------------
 impl VulkanApp {
-    pub fn main_loop(self, event_loop: EventLoop<()>) {
+    pub fn main_loop(mut self, event_loop: EventLoop<()>) {
 
          event_loop.run(move |event, _, control_flow| {
 
@@ -392,6 +396,9 @@ impl VulkanApp {
                         },
                         | _ => {},
                     }
+                },
+                | Event::EventsCleared => {
+                    self.draw_frame();
                 },
                 _ => (),
             }

--- a/src/tutorials/13_framebuffers.rs
+++ b/src/tutorials/13_framebuffers.rs
@@ -160,6 +160,10 @@ impl VulkanApp {
 
         framebuffers
     }
+
+    fn draw_frame(&mut self) {
+        // Drawing will be here
+    }
 }
 
 impl Drop for VulkanApp {
@@ -194,7 +198,7 @@ impl Drop for VulkanApp {
 
 // Fix content -------------------------------------------------------------------------------
 impl VulkanApp {
-    pub fn main_loop(self, event_loop: EventLoop<()>) {
+    pub fn main_loop(mut self, event_loop: EventLoop<()>) {
 
          event_loop.run(move |event, _, control_flow| {
 
@@ -218,6 +222,9 @@ impl VulkanApp {
                         },
                         | _ => {},
                     }
+                },
+                | Event::EventsCleared => {
+                    self.draw_frame();
                 },
                 _ => (),
             }

--- a/src/tutorials/14_command_buffers.rs
+++ b/src/tutorials/14_command_buffers.rs
@@ -238,6 +238,10 @@ impl VulkanApp {
 
         command_buffers
     }
+
+    fn draw_frame(&mut self) {
+        // Drawing will be here
+    }
 }
 
 impl Drop for VulkanApp {
@@ -274,7 +278,7 @@ impl Drop for VulkanApp {
 
 // Fix content -------------------------------------------------------------------------------
 impl VulkanApp {
-    pub fn main_loop(self, event_loop: EventLoop<()>) {
+    pub fn main_loop(mut self, event_loop: EventLoop<()>) {
 
          event_loop.run(move |event, _, control_flow| {
 
@@ -298,6 +302,9 @@ impl VulkanApp {
                         },
                         | _ => {},
                     }
+                },
+                | Event::EventsCleared => {
+                    self.draw_frame();
                 },
                 _ => (),
             }


### PR DESCRIPTION
This way we make sure that Drop impl for VulkanApp gets called always

Other way of fixing the issue would be switching to [event_loop.run_return](https://docs.rs/winit/0.20.0-alpha3/winit/platform/desktop/trait.EventLoopExtDesktop.html#tymethod.run_return),
but it means giving up on mobile platforms completely and having resizing
issues on Windows.