### PR TITLE
Fix min_image_count validation error if driver doesn't declare max count

### DIFF
--- a/src/tutorials/06_swap_chain_creation.rs
+++ b/src/tutorials/06_swap_chain_creation.rs
@@ -392,11 +392,12 @@ impl VulkanApp {
             VulkanApp::choose_swapchain_present_mode(&swapchain_support.present_modes);
         let extent = VulkanApp::choose_swapchain_extent(&swapchain_support.capabilities);
 
-        use std::cmp::min;
-        let image_count = min(
-            swapchain_support.capabilities.min_image_count + 1,
-            swapchain_support.capabilities.max_image_count,
-        );
+        let image_count = swapchain_support.capabilities.min_image_count + 1;
+        let image_count = if swapchain_support.capabilities.max_image_count > 0 {
+            image_count.min(swapchain_support.capabilities.max_image_count)
+        } else {
+            image_count
+        };
 
         let (image_sharing_mode, queue_family_index_count, queue_family_indices) =
             if queue_family.graphics_family != queue_family.present_family {

--- a/src/utility/share/mod.rs
+++ b/src/utility/share/mod.rs
@@ -361,12 +361,12 @@ pub fn create_swapchain(
     let present_mode = choose_swapchain_present_mode(&swapchain_support.present_modes);
     let extent = choose_swapchain_extent(&swapchain_support.capabilities, window);
 
-    // use std::cmp::min;
-    // let image_count = min(
-    //     swapchain_support.capabilities.min_image_count + 1,
-    //     swapchain_support.capabilities.max_image_count,
-    // );
-    let image_count = 2;
+    let image_count = swapchain_support.capabilities.min_image_count + 1;
+    let image_count = if swapchain_support.capabilities.max_image_count > 0 {
+        image_count.min(swapchain_support.capabilities.max_image_count)
+    } else {
+        image_count
+    };
 
     let (image_sharing_mode, queue_family_index_count, queue_family_indices) =
         if queue_family.graphics_family != queue_family.present_family {


### PR DESCRIPTION
When a driver does not declare maximum allowed image count, it returns 0 which results in setting the min image count to 0 as well, because the code checks for a min of the two.
Here's the complain from the validation error:
```
[Debug][Error][Validation]"vkCreateSwapchainKHR() called with minImageCount = 0, which is outside the bounds returned by vkGetPhysicalDeviceSurfaceCapabilitiesKHR() (i.e. minImageCount = 3, maxImageCount = 0). The Vulkan spec states: minImageCount must be greater than or equal to the value returned in the minImageCount member of the VkSurfaceCapabilitiesKHR structure returned by vkGetPhysicalDeviceSurfaceCapabilitiesKHR for the surface (https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#VUID-VkSwapchainCreateInfoKHR-minImageCount-01271)"
```
I suspect that this might've been the reason for #3 

This PR fixes the issue by picking a minimum only if `max_image_count` is greater than 0