### PR TITLE
Fix wrong vertex pos data in Example 17

### DIFF
--- a/src/tutorials/17_vertex_input.rs
+++ b/src/tutorials/17_vertex_input.rs
@@ -62,7 +62,7 @@ const _VERTICES_DATA: [Vertex; 3] = [
         color: [0.0, 1.0, 0.0],
     },
     Vertex {
-        pos: [-0.5, -0.5],
+        pos: [-0.5, 0.5],
         color: [0.0, 0.0, 1.0],
     },
 ];


### PR DESCRIPTION
3rd Vertex position is a bit incorrect. Next chapters have it correctly.